### PR TITLE
Fix success message placement

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,9 @@ uploaded_file = st.file_uploader("XLSXファイルをアップロードしてく
 if uploaded_file is not None:
     # ファイルがアップロードされた場合の処理
     try:
+        # アップロードされたXLSXファイルを読み込み
+        df = pd.read_excel(uploaded_file, engine="openpyxl")
+
         st.success(f"ファイル '{uploaded_file.name}' のアップロードに成功しました！")
         st.write("---")
         st.subheader("アップロードされたファイルの情報:")
@@ -18,9 +21,8 @@ if uploaded_file is not None:
         st.write(f"ファイルタイプ: {uploaded_file.type}")
         st.write("---")
 
-        # アップロードされたXLSXファイルの内容をPandasで読み込み、先頭5行を表示
+        # 読み込んだXLSXファイルの内容を表示
         st.subheader("ファイル内容のプレビュー (先頭5行):")
-        df = pd.read_excel(uploaded_file)
         st.dataframe(df.head())
 
         st.info("ファイルの読み込みと表示が正常に完了しました。")
@@ -28,5 +30,6 @@ if uploaded_file is not None:
     except Exception as e:
         st.error(f"ファイルの処理中にエラーが発生しました: {e}")
         st.error("アップロードしたファイルが正しいXLSX形式であるか確認してください。")
+        st.exception(e)
 else:
     st.info("上の「Browse files」ボタンを押すか、ファイルをドラッグ＆ドロップしてアップロードしてください。")


### PR DESCRIPTION
## Summary
- only show upload success message after Excel file loads correctly
- ensure newline at end of the app script
- specify openpyxl engine when reading Excel files
- display exception details when an error occurs

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684d27195e5c8329973e46182da019d7